### PR TITLE
Fixed issue with vendor library caches in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(OpenCV REQUIRED)
 find_package(PROJ REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(CURL REQUIRED) 
-find_package(caches REQUIRED)
+find_package(caches CONFIG REQUIRED PATHS ${CMAKE_INSTALL_PREFIX}/../caches/lib/cmake/caches)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
   add_compile_options(-O3)

--- a/test/cache/.gitignore
+++ b/test/cache/.gitignore
@@ -1,0 +1,1 @@
+cached.map


### PR DESCRIPTION
Fixed issue with vendor library caches in CMakeLists.txt.

Issue: 
CMake correctly generates a cachesConfig.cmake in a path that should be searched by default, but does not find it at first build run (while it succeeds in all subsequent build runs). 
Fix:
Added a respective PATH parameter to the find_package() command in question. Now succeeds at first build run.

(I also put cached.map to a .gitignore file - this is not related to the fix).

This PR is related to [PR 5](https://github.com/eclipse-adore/adore_map/pull/5) of adore_map, and to [PR 83](https://github.com/eclipse-adore/adore/pull/83) of adore.

It must be merged before [PR 83](https://github.com/eclipse-adore/adore/pull/83) of adore can be merged successfully.
