### PR TITLE
Bugfix/wfs downloader

### DIFF
--- a/include/adore_map/map_cache.hpp
+++ b/include/adore_map/map_cache.hpp
@@ -179,8 +179,14 @@ public:
         entry_count++;
       }
       file.close();
-      // Delete cached.map file after loading contents into memory
-      std::remove( ( my_file_cache_path + "cached.map" ).c_str() );
+      // Delete previous copy of the cached.map file if it exists
+      std::remove( ( my_file_cache_path + "cached.map.backup" ).c_str() );
+      // Rename the current cached.map file to cached.map.backup as a backup      
+      if( std::rename( ( my_file_cache_path + "cached.map" ).c_str(), 
+        ( my_file_cache_path + "cached.map.backup" ).c_str() ) != 0 )
+      {
+        std::cerr << "MapCache::set_up_file_cache_path: Failed to rename cached.map to cached.map.backup." << std::endl;
+      }
     } 
     else 
     {

--- a/include/adore_map/xcache.hpp
+++ b/include/adore_map/xcache.hpp
@@ -77,19 +77,33 @@ public:
   void 
   clear()
   {
-    operation_guard lock{ safe_op };
+    // Collect iterators to all elements in the cache
+    std::vector<const_iterator> elems;
     for( const_iterator it = base_type::begin(); it != base_type::end(); )
-    { 
+    {
+      elems.push_back( it++ );
+    }
+    // Sort the iterators to the elements in the order they were added to the cache (oldest first)
+    // This ensures that the order of entries in cached.map stays the same if no new entries have been added
+    std::sort( elems.begin(), elems.end(), []( const_iterator a, const_iterator b )
+                                           {
+                                             return *a->second < *b->second; // Ascending order based on value
+                                           } );
+
+    operation_guard lock{ safe_op };
+    for( const_iterator elem : elems ) {
       if( debug_mode )
       {
-        std::cout << "XCache::clear: Erasing element with key: " << it->first << std::endl;
+        std::cout << "XCache::clear: Erasing element with key: " << elem->first << std::endl;
       }
-      base_type::Erase( it++ ); 
+      base_type::Erase( elem ); 
       if( debug_mode )
       {
         std::cout << "XCache::clear: Erased element." << std::endl;
       }
     }
+
+    elems.clear();
   }
 private: 
 

--- a/src/r2s_parser.cpp
+++ b/src/r2s_parser.cpp
@@ -263,13 +263,13 @@ parse_reference_lines( MapDownloader& downloader )
         {
           border.predecessor_id = properties.value( "predecessor_id", 0 );
         }
-        if( properties[ "datasource_description_id" ].is_null() )
+        if( properties[ "datasourcedescription_id" ].is_null() )
         {
           border.datasource_description_id = 0;
         }
         else
         {
-          border.datasource_description_id = properties.value( "datasource_description_id", 0 );
+          border.datasource_description_id = properties.value( "datasourcedescription_id", 0 );
         }
         if( properties[ "turn" ].is_null() || properties[ "turn" ].get<std::string>().empty() )
         {
@@ -398,12 +398,12 @@ parse_lane_borders( MapDownloader& downloader )
         {
           border.parent_id = properties.value( "parent_id" , 0);
         }
-        if( properties[ "datasource_description_id" ].is_null() ) {
+        if( properties[ "datasourcedescription_id" ].is_null() ) {
           border.datasource_description_id = 0;
         }
         else
         {
-          border.datasource_description_id = properties.value( "datasource_description_id" , 0 );
+          border.datasource_description_id = properties.value( "datasourcedescription_id" , 0 );
         }
         if( properties[ "material" ].is_null() || properties[ "material" ].get<std::string>().empty() ) {
           border.material = "NULL";

--- a/test/cache/.gitignore
+++ b/test/cache/.gitignore
@@ -1,1 +1,1 @@
-cached.map
+cached.map.backup


### PR DESCRIPTION
This PR comprises the following:

- Correction of a typo in adore_libraries/adore_map/src/r2s_parser.cpp:

`properties[ "datasource_description_id" ]` -> `properties[ "datasourcedescription_id" ] `(2 times)
`properties.value( "datasource_description_id", 0 ) ` -> `properties.value( "datasourcedescription_id", 0 )` (2 times)

Moreover, the code for the map cache has been improved, in detail:
  - the cached.map file is now copied to cached.map.backup at start
  - an existing previous backup file gets overwritten, the backup is .gitignore'd
  - entries in cached.map are now ordered wrt ascending entry number