### PR TITLE
Restored previous find_package command for caches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(OpenCV REQUIRED)
 find_package(PROJ REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(CURL REQUIRED) 
-find_package(caches CONFIG REQUIRED PATHS ${CMAKE_INSTALL_PREFIX}/../caches/lib/cmake/caches)
+find_package(caches CONFIG REQUIRED)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
   add_compile_options(-O3)


### PR DESCRIPTION
This PR simplifies just one line from CMakeLists.txt (a find_package command for caches). 

A PATHS parameter had been inserted as a workaround for a building issue. This has become obsolete by commit https://github.com/eclipse-adore/adore_map/commit/8d0b31adb5780a6cbf846d409444235c0584dfd3 by @akoerner1 (thanks!)